### PR TITLE
修复 Coding 图床仓库名写死的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
                 "markdown-image.coding.repository": {
                     "type": "string",
                     "default": "",
-                    "pattern": "^(https://([^.]*?).coding.net/p/([^/]*?)/(d/([^/]*?)/(git|)|)|)$",
+                    "pattern": "^(https://([^.]*?).coding.net/([^/]*?)/([^/]*?)/(d/([^/]*?)/(git|)|)|)$",
                     "markdownDescription": "%markdown-image.coding.repository%"
                 },
                 "markdown-image.imgur.clientId": {


### PR DESCRIPTION
在 vscode 中配置图床 Coding 的 repository 时，报错如下
![11](https://user-images.githubusercontent.com/24868838/124081870-9ece8080-da7e-11eb-86a4-d1951e9b416b.png)

应该是把仓库名称写死成 p 了，所以所有的仓库路径都会提示错误

更改方法是：将仓库名称使用正则匹配