### PR TITLE
Add support for Cloudinary CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 All notable changes to the "markdown-image" extension will be documented in this file.
 
+## [v.Next] - TBD
+### Added
+- Added support for Cloudinary CDN
+- Includes the following new settings:
+  * `markdown-image.cloudinary.cloudName`
+  * `markdown-image.cloudinary.apiKey`
+  * `markdown-image.cloudinary.apiSecret`
+  * `markdown-image.cloudinary.folder`
+
 ## [1.1.9] - 2021-05-17
 ### Added
 - Added setting options `markdown-image.base.codeType` and `markdown-image.base.imageWidth` use to set the maximum image width.
@@ -105,6 +114,6 @@ All notable changes to the "markdown-image" extension will be documented in this
 ## [1.0.1] - 2020-05-09
 ### Fixed
 - Fixed Readme.
-  
+
 ## [1.0.0] - 2020-05-09
 - Finish First Version.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extension for conveniently inserting pictures in Markdown, which supports sto
 
 1. Copy image files or paste screenshots, Shortcut key `Ctrl + Shift + V`, or right-click menu `Paste Image`.
 2. Automatically generate Markdown code insertion.
-3. Configurable to support `Imgur`, `Qiniu`, `SM.MS`, `Coding` and other CDN service. The default is local, you need to open the folder where the Markdown file is located.
+3. Configurable to support `Imgur`, `Qiniu`, `SM.MS`, `Coding`, `Cloudinary` and other CDN service. The default is local, you need to open the folder where the Markdown file is located.
 4. You can also customize the code to upload pictures.
 5. Support Windows, MacOS, Linux.
 
@@ -63,9 +63,16 @@ sudo yum install xclip
 - `markdown-image.qiniu.domain`: Bound domain name of storage。
 - `markdown-image.qiniu.zone`:  Zone of storage.
 
+### Cloudinary Settings
+These values can be found on your Cloudinary Dashboard
+- `markdown-image.cloudinary.cloudName`: Your user account name.
+- `markdown-image.cloudinary.apiKey`: API key for your account.
+- `markdown-image.cloudinary.apiSecret`: API secret for your account.
+- `markdown-image.cloudinary.folder`: Folder to upload the image to.
+
 ### DIY Settings
-- `markdown-image.DIY.path`: The Code Path what you write. Your code must exports a function as `async function (filePath:string, savePath:string, markdownPath:string):string`.  
-    For example: 
+- `markdown-image.DIY.path`: The Code Path what you write. Your code must exports a function as `async function (filePath:string, savePath:string, markdownPath:string):string`.
+    For example:
     ```javascript
     const path = require('path');
     module.exports = async function(filePath, savePath, markdownPath) {
@@ -75,6 +82,14 @@ sudo yum install xclip
     ```
 
 ## Release Notes
+
+### v.Next
+- Added support for Cloudinary CDN
+- Includes the following new settings:
+  * `markdown-image.cloudinary.cloudName`
+  * `markdown-image.cloudinary.apiKey`
+  * `markdown-image.cloudinary.apiSecret`
+  * `markdown-image.cloudinary.folder`
 
 ### 1.1.9
 - Added setting options `markdown-image.base.codeType` and `markdown-image.base.imageWidth` use to set the maximum image width.
@@ -133,7 +148,7 @@ sudo yum install xclip
 ### 1.0.7
 - Fixed launch extension home page failed at MacOS and Linux.
 - Fixed the colon of the picture address is incorrectly encode.
-   
+
 ### 1.0.6
 
 - Fixed the date variable has not consider the time zone.
@@ -142,7 +157,7 @@ sudo yum install xclip
 
 - Fixed file name include space could not preview.
 - Fixed random variable not work.
-  
+
 ### 1.0.4
 
 - Update sponsored links.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
                         "SM.MS",
                         "Data URL",
                         "%markdown-image.qiniu%",
-                        "%markdown-image.DIY%"
+                        "%markdown-image.DIY%",
+                        "Cloudinary"
                     ],
                     "default": "Local",
                     "description": "%markdown-image.base.uploadMethod%",
@@ -92,7 +93,8 @@
                         "%markdown-image.base.uploadMethod.SM.MS%",
                         "%markdown-image.base.uploadMethod.DataURL%",
                         "%markdown-image.base.uploadMethod.Qiniu%",
-                        "%markdown-image.base.uploadMethod.DIY%"
+                        "%markdown-image.base.uploadMethod.DIY%",
+                        "%markdown-image.base.uploadMethod.Cloudinary%"
                     ]
                 },
                 "markdown-image.base.codeType": {
@@ -197,6 +199,26 @@
                     "type": "string",
                     "default": "",
                     "markdownDescription": "%markdown-image.DIY.path%"
+                },
+                "markdown-image.cloudinary.cloudName": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "%markdown-image.cloudinary.cloudName%"
+                },
+                "markdown-image.cloudinary.apiKey": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "%markdown-image.cloudinary.apiKey%"
+                },
+                "markdown-image.cloudinary.apiSecret": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "%markdown-image.cloudinary.apiSecret%"
+                },
+                "markdown-image.cloudinary.folder": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "%markdown-image.cloudinary.folder%"
                 }
             }
         }
@@ -217,6 +239,7 @@
         "vscode": "^1.1.25"
     },
     "dependencies": {
+        "cloudinary": "^1.26.1",
         "coding-picbed": "0.0.12",
         "form-data": "^3.0.0",
         "got": "^10.7.0",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "markdown-image.local": "Local",
     "markdown-image.qiniu": "Qiniu",
     "markdown-image.DIY": "DIY",
+    "markdown-image.Cloudinary": "Cloudinary",
     "markdown-image.command.paste": "Paste Image",
     "markdown-image.command.config": "Markdown Image Config Setting",
     "markdown-image.command.paste-rich-text": "Paste Rich Text (Beta)",
@@ -14,6 +15,7 @@
     "markdown-image.base.uploadMethod.DataURL": "Turn the picture into the DATA URL insert.",
     "markdown-image.base.uploadMethod.Qiniu": "Upload the image to qiniu.com.",
     "markdown-image.base.uploadMethod.DIY": "You can define your code used to upload. You need to configure the code path through markdown-image.DIY.path",
+    "markdown-image.base.uploadMethod.Cloudinary": "Upload the image to Cloudinary. You can configure `Cloud Name` through markdown-image.cloudinary.cloudName.",
     "markdown-image.base.fileNameFormat": "The filenname and path format string for upload. Not Support in `Imgur` and `SM.MS`. You can use some variables: \n\n- `${filename}`: The original filename.  \n- `${mdname}`: The name of the Markdown file being edited.  \n- `${path}`: The path of the Markdown file being edited relative to the root directory.  \n- `${hash}`: The sha256 hash of image.  \n- `${timestamp}`: The timestamp of upload time.  \n- `${YY}`: The Year  \n-`${MM}`:The Month  \n- `${DD}`: The Day  \n- `${hh}`: The 12-hour clock  \n- `${HH}`: The 24-hour clock  \n- `${mm}`: The minutes  \n- `${ss}`: The seconds  \n- `${mss}`: The milliseconds  \n- `${rand,number}`: A random number, for example: `${rand,100}`. It will generate random numbers from 0 to 99.",
     "markdown-image.base.urlEncode": "Whether URL encode for the url of image.",
     "markdown-image.base.codeType": "The type of image code",
@@ -37,5 +39,9 @@
     "markdown-image.qiniu.south": "South China",
     "markdown-image.qiniu.na": "North America",
     "markdown-image.qiniu.sa": "Southeast Asia",
-    "markdown-image.DIY.path": "The Code File Path. You can write a Node.js code file to upload, and fill in the file path to here. Your code must exports a function as `async function (filePath:string, savePath:string, markdownPath:string):string`.\n\nFor example: \n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\nThe arguments are :\n- `filePath`: The absolute path of the file.  \n- `savePath`: The path of the saved file generate according to `#markdown-image.base.format#`.  \n- `markdownPath`: The path of markdown file being edited."
+    "markdown-image.DIY.path": "The Code File Path. You can write a Node.js code file to upload, and fill in the file path to here. Your code must exports a function as `async function (filePath:string, savePath:string, markdownPath:string):string`.\n\nFor example: \n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\nThe arguments are :\n- `filePath`: The absolute path of the file.  \n- `savePath`: The path of the saved file generate according to `#markdown-image.base.format#`.  \n- `markdownPath`: The path of markdown file being edited.",
+    "markdown-image.cloudinary.cloudName": "Your user account name.",
+    "markdown-image.cloudinary.apiKey": "API key for your account.",
+    "markdown-image.cloudinary.apiSecret": "API secret for your account.",
+    "markdown-image.cloudinary.folder": "Folder to upload the image to."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -3,6 +3,7 @@
     "markdown-image.local": "本地",
     "markdown-image.qiniu": "七牛",
     "markdown-image.DIY": "自定义",
+    "markdown-image.Cloudinary": "Cloudinary",
     "markdown-image.command.paste": "粘贴图片",
     "markdown-image.command.config": "Markdown 图片配置",
     "markdown-image.command.paste-rich-text": "粘贴富文本 (Beta)",
@@ -14,6 +15,7 @@
     "markdown-image.base.uploadMethod.DataURL": "将图片转为Data URL 插入.",
     "markdown-image.base.uploadMethod.Qiniu": "将图片上传到七牛对象存储，你有很多项目需要配置。",
     "markdown-image.base.uploadMethod.DIY": "您可以自定义用于上传的代码。您需要通过 markdown-image.DIY.path 配置代码路径。",
+    "markdown-image.base.uploadMethod.Cloudinary": "Upload the image to Cloudinary. You can configure `Cloud Name` through markdown-image.cloudinary.cloudName.",
     "markdown-image.base.fileNameFormat": "上传的文件名与路径的格式字符串。不支持 `Imgur` 和 `SM.MS`。 你有一些变量可以使用：  \n\n- `${filename}`: 图片原始的文件名。  \n- `${mdname}`: 正在编辑的 Markdown 文件的名称（不含扩展名）。  \n- `${path}`: 正在编辑的 Markdown 文件相对于根目录的路径。  \n- `${hash}`: 图像的 sha256 哈希。  \n- `${timestamp}`: 上传时间的时间戳。  \n- `${YY}`: 年份  \n-`${MM}`: 月份  \n- `${DD}`: 日期  \n- `${hh}`: 12小时制小时  \n- `${HH}`: 24小时制小时  \n- `${mm}`: 分  \n- `${ss}`: 秒  \n- `${mss}`: 毫秒  \n- `${rand,number}`: 随机数, 比如：`${rand,100}`. 它将生成从 0 到 99 的随机数。",
     "markdown-image.base.urlEncode": "是否对图像的 URL 编码。",
     "markdown-image.base.codeType": "插入代码的类型",
@@ -37,5 +39,9 @@
     "markdown-image.qiniu.south": "华南",
     "markdown-image.qiniu.na": "北美",
     "markdown-image.qiniu.sa": "东南亚",
-    "markdown-image.DIY.path": "你写的代码的绝对路径。你可以写一个 Node.js 代码文件用于上传，并在此处填写文件路径。你的代码必须 exports 一个像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函数。\n\n比如：\n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\n函数参数分别是：\n- `filePath`: 文件的绝对路径。  \n- `savePath`: 保存的文件的路径，根据 `#markdown-image.base.fileNameFormat#` 生成。  \n- `markdownPath`: 正在编辑的 markdown 文件的路径。"
+    "markdown-image.DIY.path": "你写的代码的绝对路径。你可以写一个 Node.js 代码文件用于上传，并在此处填写文件路径。你的代码必须 exports 一个像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函数。\n\n比如：\n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\n函数参数分别是：\n- `filePath`: 文件的绝对路径。  \n- `savePath`: 保存的文件的路径，根据 `#markdown-image.base.fileNameFormat#` 生成。  \n- `markdownPath`: 正在编辑的 markdown 文件的路径。",
+    "markdown-image.cloudinary.cloudName": "Your user account name.",
+    "markdown-image.cloudinary.apiKey": "API key for your account.",
+    "markdown-image.cloudinary.apiSecret": "API secret for your account.",
+    "markdown-image.cloudinary.folder": "Folder to upload the image to."
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -3,6 +3,7 @@
     "markdown-image.local": "本地",
     "markdown-image.qiniu": "七牛",
     "markdown-image.DIY": "自定義",
+    "markdown-image.Cloudinary": "Cloudinary",
     "markdown-image.command.paste": "粘貼圖片",
     "markdown-image.command.config": "Markdown 圖片配置",
     "markdown-image.command.paste-rich-text": "粘貼富文本 (Beta)",
@@ -14,6 +15,7 @@
     "markdown-image.base.uploadMethod.DataURL": "將圖片轉爲Data URL 插入.",
     "markdown-image.base.uploadMethod.Qiniu": "將圖片上傳到七牛對象存儲，你有很多項目需要配置。",
     "markdown-image.base.uploadMethod.DIY": "您可以自定義用於上傳的代碼。您需要通過 markdown-image.DIY.path 配置代碼路徑。",
+    "markdown-image.base.uploadMethod.Cloudinary": "Upload the image to Cloudinary. You can configure `Cloud Name` through markdown-image.cloudinary.cloudName.",
     "markdown-image.base.fileNameFormat": "上傳的文件名和路徑的格式字符串。不支持 `Imgur` 和 `SM.MS`。 你有一些變量可以使用： \n\n- `${filename}`: 圖片原始的文件名。  \n- `${mdname}`: 正在編輯的 Markdown 文件的名稱（不含擴展名）。  \n- `${path}`: 正在編輯的 Markdown 文件相對於根目錄的路徑。  \n- `${hash}`: 圖像的 sha256 哈希。  \n- `${timestamp}`: 上傳時間的時間戳。  \n- `${YY}`: 年份  \n- `${MM}`: 月份  \n- `${DD}`: 日期  \n- `${hh}`: 12小時制小時  \n- `${HH}`: 24小時制小時  \n- `${mm}`: 分  \n- `${ss}`: 秒  \n- `${mss}`: 毫秒  \n- `${rand,number}`: 隨機數, 比如：`${rand,100}`. 它將生成從 0 到99 的隨機數。",
     "markdown-image.base.urlEncode": "是否對圖像的 URL 編碼。",
     "markdown-image.base.codeType": "插入代碼的類型",
@@ -37,5 +39,9 @@
     "markdown-image.qiniu.south": "華南",
     "markdown-image.qiniu.na": "北美",
     "markdown-image.qiniu.sa": "東南亞",
-    "markdown-image.DIY.path": "你寫的代碼的絕對路徑。你可以寫一個 Node.js 代碼文件用於上傳，並在此處填寫文件路徑。你的代碼必須 exports 一個像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函數。\n \n比如：\n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\n函數參數分別是：\n- `filePath`: 文件的絕對路徑。 \n- `savePath` : 保存的文件的路徑，根據 `#markdown-image.base.fileNameFormat#` 生成。 \n- `markdownPath`: 正在編輯的 markdown 文件的路徑。"
+    "markdown-image.DIY.path": "你寫的代碼的絕對路徑。你可以寫一個 Node.js 代碼文件用於上傳，並在此處填寫文件路徑。你的代碼必須 exports 一個像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函數。\n \n比如：\n\n ```javascript\nconst path = require('path');\nmodule.exports = async function(filePath, savePath, markdownPath) {\n\t// Return a picture access link\n\treturn path.relative(path.dirname(markdownPath), filePath); \n}\n```\n函數參數分別是：\n- `filePath`: 文件的絕對路徑。 \n- `savePath` : 保存的文件的路徑，根據 `#markdown-image.base.fileNameFormat#` 生成。 \n- `markdownPath`: 正在編輯的 markdown 文件的路徑。",
+    "markdown-image.cloudinary.cloudName": "Your user account name.",
+    "markdown-image.cloudinary.apiKey": "API key for your account.",
+    "markdown-image.cloudinary.apiSecret": "API secret for your account.",
+    "markdown-image.cloudinary.folder": "Folder to upload the image to."
 }

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,43 @@
+//@ts-ignore
+import * as vscode from "vscode";
+import { locale as $l } from "./utils";
+import { v2 as cloudinary } from "cloudinary";
+
+class Cloudinary implements Upload {
+  config: Config;
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  async getSavePath(filePath: string) {
+    return filePath;
+  }
+
+  async reconfig(config: Config) {
+    this.config = config;
+  }
+
+  async upload(filePath: string, savePath: string): Promise<string | null> {
+    try {
+      cloudinary.config({
+        cloud_name: this.config.cloudinary.cloudName,
+        api_key: this.config.cloudinary.apiKey,
+        api_secret: this.config.cloudinary.apiSecret,
+      });
+
+      const result = await cloudinary.uploader.upload(filePath, {
+        folder: this.config.cloudinary.folder,
+        fetch_format: "auto",
+        quality: "auto",
+      });
+      return result.secure_url;
+    } catch (e) {
+      vscode.window.showInformationMessage(
+        `${$l["upload_failed"]}${e.message}`
+      );
+      return null;
+    }
+  }
+}
+
+export default Cloudinary;

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -5,7 +5,8 @@ import SM_MS from './sm.ms';
 import Qiniu from './qiniu';
 import DataUrl from './dataurl';
 import Define from './define';
+import Cloudinary from './cloudinary'
 
 export default {
-    Local, Coding, Imgur, SM_MS, Qiniu, DataUrl, Define
+    Local, Coding, Imgur, SM_MS, Qiniu, DataUrl, Define, Cloudinary
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,6 +26,7 @@ function getUpload(config: Config) : Upload | null {
         case '七牛': return new Uploads.Qiniu(config);
         case '自定义': return new Uploads.Define(config);
         case '自定義': return new Uploads.Define(config);
+        case 'Cloudinary': return new Uploads.Cloudinary(config);
     }
     return null;
 }
@@ -102,7 +103,7 @@ async function formatName(format: string, filePath: string, isPaste: boolean): P
         if (!mat) { continue; }
         switch(variables[i]) {
             case 'filename': {
-                let data = !isPaste ? path.basename(filePath, path.extname(filePath)) : 
+                let data = !isPaste ? path.basename(filePath, path.extname(filePath)) :
                     (path.basename((await prompt(locale['named_paste'], path.basename(filePath, '.png'))) || '') || '');
                 saveName = saveName.replace(reg, data);
                 break;
@@ -122,7 +123,7 @@ async function formatName(format: string, filePath: string, isPaste: boolean): P
                 saveName = saveName.replace(reg, data);
                 break;
             }
-            case 'timestramp': 
+            case 'timestramp':
             case 'timestamp': {
                 let data = new Date().getTime().toString();
                 saveName = saveName.replace(reg, data);
@@ -182,20 +183,20 @@ async function formatName(format: string, filePath: string, isPaste: boolean): P
         }
     }
 
-    
+
     return saveName + (filePath ? path.extname(filePath) : '.png');
 }
 
-function mkdirs(dirname: string) {  
-    //console.debug(dirname);  
-    if (fs.existsSync(dirname)) {  
-        return true;  
-    } else {  
-        if (mkdirs(path.dirname(dirname))) {  
-            fs.mkdirSync(dirname);  
-            return true;  
-        }  
-    }  
+function mkdirs(dirname: string) {
+    //console.debug(dirname);
+    if (fs.existsSync(dirname)) {
+        return true;
+    } else {
+        if (mkdirs(path.dirname(dirname))) {
+            fs.mkdirSync(dirname);
+            return true;
+        }
+    }
 }
 
 function html2Markdown(data: string) : string {
@@ -209,8 +210,8 @@ function getConfig() {
     let values: Config = {};
     function toVal(str: string, val: string|undefined, cfg: Config) : string | Config {
         let keys = str.split('.');
-        if (keys.length === 1) { 
-            cfg[keys[0]] = val; 
+        if (keys.length === 1) {
+            cfg[keys[0]] = val;
         } else {
             cfg[keys[0]] = toVal(keys.slice(1).join('.'), val, cfg[keys[0]] || {});
         }
@@ -223,19 +224,19 @@ function getConfig() {
 function getPasteImage(imagePath: string) : Promise<string[]>{
     return new Promise((resolve, reject) => {
         if (!imagePath) { return; }
-    
+
         let platform = process.platform;
         if (platform === 'win32') {
             // Windows
             const scriptPath = path.join(__dirname, '..', '..' , 'asserts/pc.ps1');
-    
+
             let command = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
             let powershellExisted = fs.existsSync(command);
             let output = '';
             if (!powershellExisted) {
                 command = "powershell";
             }
-    
+
             const powershell = spawn(command, [
                 '-noprofile',
                 '-noninteractive',
@@ -272,7 +273,7 @@ function getPasteImage(imagePath: string) : Promise<string[]>{
         else if (platform === 'darwin') {
             // Mac
             let scriptPath = path.join(__dirname, '..', '..' , 'asserts/mac.applescript');
-    
+
             let ascript = spawn('osascript', [scriptPath, imagePath]);
             ascript.on('error', (e: any) => {
                 vscode.window.showErrorMessage(e);
@@ -284,10 +285,10 @@ function getPasteImage(imagePath: string) : Promise<string[]>{
                 resolve(data.toString().trim().split('\n'));
             });
         } else {
-            // Linux 
-    
+            // Linux
+
             let scriptPath = path.join(__dirname, '..', '..' , 'asserts/linux.sh');
-    
+
             let ascript = spawn('sh', [scriptPath, imagePath]);
             ascript.on('error', (e: any) => {
                 vscode.window.showErrorMessage(e);
@@ -309,19 +310,19 @@ function getPasteImage(imagePath: string) : Promise<string[]>{
 }
 
 function getRichText() : Promise<string>{
-    return new Promise((resolve, reject) => {    
+    return new Promise((resolve, reject) => {
         let platform = process.platform;
         if (platform === 'win32') {
             // Windows
             const scriptPath = path.join(__dirname, '..', '..' , 'asserts/rtf.ps1');
-    
+
             let command = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
             let powershellExisted = fs.existsSync(command);
             let output = '';
             if (!powershellExisted) {
                 command = "powershell";
             }
-    
+
             const powershell = spawn(command, [
                 '-noprofile',
                 '-noninteractive',
@@ -360,10 +361,10 @@ function getRichText() : Promise<string>{
         else if (platform === 'darwin') {
             // Mac
             vscode.window.showInformationMessage('Not support in macos yet.');
-            resolve(''); 
+            resolve('');
         } else {
-            // Linux 
-    
+            // Linux
+
             let scriptPath = path.join(__dirname, '..', '..' , 'asserts/rtf.sh');
             let result = '';
             let ascript = spawn('sh', [scriptPath]);


### PR DESCRIPTION
Includes the following new settings:

* markdown-image.cloudinary.cloudName
* markdown-image.cloudinary.apiKey
* markdown-image.cloudinary.apiSecret
* markdown-image.cloudinary.folder

I also updated the README and CHANGELOG but did not assign a version, since I'm not sure how you prefer to version this extension.