### PR TITLE
Add support for `savePath` in Cloudinary CDN and prompt to replace file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the "markdown-image" extension will be documented in this file.
 
+## [v.Next] - TBD
+### Fixed
+- Updated Cloudinary CDN to use the `markdown-image.base.fileNameFormat` setting. The extension will check for existing files and will prompt to overwrite if necessary.
+
 ## [1.1.10] - 2021-07-05
 ### Added
 - Added support for Cloudinary CDN

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ These values can be found on your Cloudinary Dashboard
 
 ## Release Notes
 
+### [v.Next]
+- Updated Cloudinary CDN to use the `markdown-image.base.fileNameFormat` setting. The extension will check for existing files and will prompt to overwrite if necessary.
+
 ### 1.1.10
 - Added support for Cloudinary CDN
 - Includes the following new settings:

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,43 +1,66 @@
-//@ts-ignore
 import * as vscode from "vscode";
-import { locale as $l } from "./utils";
-import { v2 as cloudinary } from "cloudinary";
+import utils, { locale as $l } from "./utils";
+import { UploadApiResponse, v2 as cloudinary } from "cloudinary";
 
 class Cloudinary implements Upload {
-    config: Config;
-    constructor(config: Config) {
-        this.config = config;
-    }
+  config: Config;
+  constructor(config: Config) {
+    this.config = config;
+  }
 
-    async getSavePath(filePath: string) {
-        return filePath;
-    }
+  async getSavePath(filePath: string) {
+    return filePath;
+  }
 
-    async reconfig(config: Config) {
-        this.config = config;
-    }
+  async reconfig(config: Config) {
+    this.config = config;
+  }
 
-    async upload(filePath: string, savePath: string): Promise<string | null> {
-        try {
-            cloudinary.config({
-                cloud_name: this.config.cloudinary.cloudName,
-                api_key: this.config.cloudinary.apiKey,
-                api_secret: this.config.cloudinary.apiSecret,
-            });
-
-            const result = await cloudinary.uploader.upload(filePath, {
-                folder: this.config.cloudinary.folder,
-                fetch_format: "auto",
-                quality: "auto",
-            });
-            return result.secure_url;
-        } catch (e) {
-            vscode.window.showInformationMessage(
-                `${$l["upload_failed"]}${e.message}`
-            );
-            return null;
+  async upload(filePath: string, savePath: string): Promise<string | null> {
+    try {
+      let result = await this.doUpload(filePath, savePath, {
+        overwrite: false,
+      });
+      if (result.existing) {
+        const replace = await utils.confirm($l["replace_or_no"], [
+          $l["Yes"],
+          $l["No"],
+        ]);
+        if (replace === $l["No"]) {
+          return null;
         }
+        // yes, so re-upload with overwrite: true
+        result = await this.doUpload(filePath, savePath, { overwrite: true });
+      }
+      return result.secure_url;
+    } catch (e) {
+      vscode.window.showInformationMessage(
+        `${$l["upload_failed"]}${e.message}`,
+      );
+      return null;
     }
+  }
+
+  async doUpload(
+    filePath: string,
+    savePath: string,
+    config: { overwrite: boolean },
+  ): Promise<UploadApiResponse> {
+    cloudinary.config({
+      cloud_name: this.config.cloudinary.cloudName,
+      api_key: this.config.cloudinary.apiKey,
+      api_secret: this.config.cloudinary.apiSecret,
+    });
+    return cloudinary.uploader.upload(filePath, {
+      folder: this.config.cloudinary.folder,
+      filename_override: savePath,
+      use_filename: true,
+      unique_filename: false,
+      overwrite: config.overwrite,
+      fetch_format: "auto",
+      quality: "auto",
+    });
+  }
 }
 
 export default Cloudinary;

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import utils, { locale as $l } from "./utils";
 import { UploadApiResponse, v2 as cloudinary } from "cloudinary";
 
@@ -44,19 +45,26 @@ class Cloudinary implements Upload {
   async doUpload(
     filePath: string,
     savePath: string,
-    config: { overwrite: boolean },
+    options: { overwrite: boolean },
   ): Promise<UploadApiResponse> {
     cloudinary.config({
       cloud_name: this.config.cloudinary.cloudName,
       api_key: this.config.cloudinary.apiKey,
       api_secret: this.config.cloudinary.apiSecret,
     });
+
+    const folder = path.join(
+      this.config.cloudinary.folder,
+      path.dirname(savePath),
+    );
+    const filename = path.basename(savePath);
+
     return cloudinary.uploader.upload(filePath, {
-      folder: this.config.cloudinary.folder,
-      filename_override: savePath,
+      folder: folder,
+      filename_override: filename,
       use_filename: true,
       unique_filename: false,
-      overwrite: config.overwrite,
+      overwrite: options.overwrite,
       fetch_format: "auto",
       quality: "auto",
     });


### PR DESCRIPTION
Updated the Cloudinary CDN uploader to use the `savePath` argument when uploading a file. This may cause conflicts with existing files that have already been uploaded. If the file already exists, the extension will prompt the user to confirm if they want to overwrite the existing file. If yes, then the file will be re-uploaded with the option `overwrite: true`.