### PR TITLE
Local: Reference Path. It should not omit `./`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-image",
   "displayName": "Markdown Image",
   "description": "Easy to insert a image to markdown",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "publisher": "hancel",
   "engines": {
     "vscode": "^1.33.0"
@@ -289,6 +289,7 @@
     "qiniu": "^7.3.1",
     "turndown": "^7.0.0",
     "turndown-plugin-gfm": "^1.0.2",
+    "vsce": "^2.14.0",
     "vscode-nls": "^4.1.2"
   }
 }

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -42,11 +42,11 @@ class Local implements Upload
             fs.copyFileSync(filePath, savePath);
 
             if(this.config.local.referencePath === '') { 
-                let linkPath = path.relative(path.dirname(utils.getCurrentFilePath()), savePath).replace(/\\/g, '/'); 
+                let linkPath = path.relative(path.dirname(utils.getCurrentFilePath()), savePath); 
                 if(!linkPath.startsWith('..')){
-                    linkPath = '.' + path.seq + linkPath;
+                    linkPath = '.' + path.sep + linkPath;
                 }
-                return linkPath;
+                return linkPath.replace(/\\/g, '/');
             }
             
             return path.join(await utils.formatName(this.config.local.referencePath, savePath, false), path.basename(savePath)).replace(/\\/g, '/')

--- a/src/lib/local.ts
+++ b/src/lib/local.ts
@@ -42,7 +42,11 @@ class Local implements Upload
             fs.copyFileSync(filePath, savePath);
 
             if(this.config.local.referencePath === '') { 
-                return path.relative(path.dirname(utils.getCurrentFilePath()), savePath).replace(/\\/g, '/'); 
+                let linkPath = path.relative(path.dirname(utils.getCurrentFilePath()), savePath).replace(/\\/g, '/'); 
+                if(!linkPath.startsWith('..')){
+                    linkPath = '.' + path.seq + linkPath;
+                }
+                return linkPath;
             }
             
             return path.join(await utils.formatName(this.config.local.referencePath, savePath, false), path.basename(savePath)).replace(/\\/g, '/')


### PR DESCRIPTION
hi, bro, your work is pretty excellent.

when i use this plug to write a markdown document in vuepress, it ocurrs the problem about image link. Vuepress has this rule: `![](./image/a.png)` is valid while `![](image/a.png)` is invaild.

In my opinion, although `![](image/a.png)`  works well, i think it is better to use `![](./image/a.png)` instead of `![](image/a.png)` to express a relative path.

i find this problem is caused by the omission `./` of `path.relative()`, and i append a `./` deal.

