### PR TITLE
添加 markdown-image.github.httpProxy 配置项支持通过代理访问 github 上传图片 && 修正Linux环境上传失败问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ sudo yum install xclip
 ## Notice
 
 If you want to use in the Remote Mode, please set `remote.extensionKind` like this:
+
 ```json
 "remote.extensionKind": {
   "hancel.markdown-image": [
     "ui"
   ]
 }
-``` 
+```
 
 And if you want to save image in your remote workplace, you must use `SFTP` upload method. `Local` couldn't use in Remote Mode.
 
@@ -72,6 +73,7 @@ And if you want to save image in your remote workplace, you must use `SFTP` uplo
 - `markdown-image.github.repository`: GitHub repository, for example: `https://github.com/username/repository`
 - `markdown-image.github.branch`: GitHub repository branch to save.
 - `markdown-image.github.cdn`: The github cdn address format to be used, `${username}` is the username of `markdown-image.github.repository`, and `${repository}` is the repository name. `${branch}` is the value of `markdown-image.github.branch`. `${filepath}` is the upload path in repository.
+- `markdown-image.github.httpProxy`: Connect to Github via http proxy.
 
 ### Imgur Settings
 
@@ -150,6 +152,7 @@ These values can be found in your S3 service provider dashboard
 ## Release Notes
 
 ### 1.1.29
+
 - Fix failed to get image from clipboard on deepin.
 
 ### 1.1.28

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -8,7 +8,7 @@
 
 ## 功能
 
-1. 可复制图片文件或截图粘贴，快捷键 `Alt + Shift + V`，或右键菜单`粘贴图片`。
+1. 可复制图片文件或截图粘贴，快捷键 `Alt + Shift + V`，或右键菜单 `粘贴图片`。
 2. 自动生成 Markdown 代码插入。
 3. 可配置支持 `Imgur`，`七牛`，`SM.MS`，`Coding` 等图床。默认为本地，需打开 Markdown 文件所在文件夹。
 4. 也可以自定义代码实现图片上传。
@@ -19,25 +19,29 @@
 Windows 和 MacOS 用户可直接使用，Linux 用户须安装 xclip.
 
 Ubuntu
+
 ```bash
 sudo apt install xclip
 ```
 
 CentOS
+
 ```bash
 sudo yum install epel-release.noarch
 sudo yum install xclip
 ```
+
 ## 注意事项
 
 如果你要在 Remote 模式中使用，请设置 `remote.extensionKind` 如下：
+
 ```json
 "remote.extensionKind": {
   "hancel.markdown-image": [
     "ui"
   ]
 }
-``` 
+```
 
 而且，如果要将图片保存在远程工作目录中，则必须使用 `SFTP` 上传方法，`Local` 方法无法在 Remote 模式中使用。
 
@@ -69,10 +73,11 @@ sudo yum install xclip
 - `markdown-image.github.repository`: 所要上传的目的仓库，比如：`https://github.com/username/repository/`。仓库必须要先初始化。
 - `markdown-image.github.branch`: 要存放图片的仓库分支。
 - `markdown-image.github.cdn`: 要使用的 CDN 地址格式，`${username}` 表示上传仓库的用户名，`${repository}` 表示上传的仓库，`${branch}` 表示上传的分支，`${filepath}` 表示上传的仓库目录与文件名。
+- `markdown-image.github.httpProxy` : 设置访问Github的 HTTP 代理。
 
 ### Imgur 设置项目
 
-- `markdown-image.imgur.clientId`: 在 `imgur` 注册的`Client Id`。您可以在[这儿](https://api.imgur.com/oauth2/addclient)注册。
+- `markdown-image.imgur.clientId`: 在 `imgur` 注册的 `Client Id`。您可以在[这儿](https://api.imgur.com/oauth2/addclient)注册。
 - `markdown-image.imgur.httpProxy`: 设置访问的 HTTP 代理。
 
 ### SM.MS 设置项目
@@ -97,14 +102,18 @@ sudo yum install xclip
 - `markdown-image.upyun.link`:  又拍云链接线路。
 
 ### Cloudinary 设置项目
+
 这些值可以在 Cloudinary Dashboard 上找到
+
 - `markdown-image.cloudinary.cloudName`: 你的帐户名称。
 - `markdown-image.cloudinary.apiKey`: 你的帐户 API key。
 - `markdown-image.cloudinary.apiSecret`: 你的用户帐户 API secret。
 - `markdown-image.cloudinary.folder`: 图像上传文件夹。
 
 ### Cloudflare 设置项目
+
 这些值可以在 CloudFlare Dashboard 上找到
+
 - `markdown-image.cloudflare.accountId`: 你的帐户名称
 - `markdown-image.cloudflare.apiToken`: Cloudflare API 令牌。
 
@@ -128,22 +137,22 @@ sudo yum install xclip
 - `markdown-image.sftp.path`: 远程服务器的图片存储目录（如果不存在，则自动创建）。支持相对路径，相对于所粘贴的 Markdown 文件。 `/` 表示打开的文件夹根目录。注意：您不能在此处使用变量。您可以在 `#markdown-image.base.fileNameFormat#` 中使用变量。
 - `markdown-image.sftp.referencePath`: Markdown 中的图片的引用路径格式（不包含文件名）。留空表示使用相对路径。 你可以使用 `#markdown-image.base.fileNameFormat#` 中的所有变量。例如：`/images/${YY}-${MM}/`
 
-
 ### 自定义设置项目
 
-- `markdown-image.DIY.path`: 你写的代码的路径。 你的代码必须 exports 一个像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函数。   
-    比如：
-    ```javascript
-    const path = require('path');
-    module.exports = async function(filePath, savePath, markdownPath) {
-        // Return a picture access link
-        return path.relative(path.dirname(markdownPath), filePath);
-    }
-    ```
+- `markdown-image.DIY.path`: 你写的代码的路径。 你的代码必须 exports 一个像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函数。
+  比如：
+  ```javascript
+  const path = require('path');
+  module.exports = async function(filePath, savePath, markdownPath) {
+      // Return a picture access link
+      return path.relative(path.dirname(markdownPath), filePath);
+  }
+  ```
 
 ## 发布历史
 
 ### 1.1.29
+
 - 修正在 Deepin 系统无法获取剪贴板图片的问题。
 
 ### 1.1.28
@@ -171,6 +180,7 @@ sudo yum install xclip
   - `markdown-image.s3.secretAccessKey`
 
 ### 1.1.26
+
 - 添加了对 又拍云 支持.
 - 新增了包括以下新的设置：
   * `markdown-image.upyun.bucket`
@@ -181,55 +191,71 @@ sudo yum install xclip
   * `markdown-image.upyun.link`
 
 ### 1.1.25
+
 - 修正当开启 `markdown-image.base.urlEncode` 时，GitHub CDN 地址编码错误的问题。
 
 ### 1.1.24
+
 - 修正一些 `markdown-image.local.referencePath` 的使用 bug；
 - 修正图片 `alt` 计数在重载控件重新开始的问题。
 
 ### 1.1.23
+
 - 添加了新设置项目 `markdown-image.github.cdn` 去设置 GitHub CDN 地址.
 
 ### 1.1.22
+
 - 修复 GitHub 模式上传文件路径错误问题。
 
 ### 1.1.21
+
 - 修复了当文件路径包含中文时，上传到 GitHub 失败的问题。
 
 ### 1.1.20
+
 - 修复 Local 模式设置 `local.reference Path` 以 `/` 开始的值导致路径从磁盘根目录开始的问题。
 
 ### 1.1.19
+
 - 修复 Local 模式设置保存到项目根目录，实际保存到磁盘根目录问题。
 
 ### 1.1.18
+
 - 修复 Local 模式不能使用绝对路径的问题。
 
 ### 1.1.17
+
 - 添加了对 Cloudflare CDN 支持.
 - 新增了包括以下新的设置：
   * `markdown-image.cloudflare.accountId`
   * `markdown-image.cloudflare.apiToken`
 
 ### 1.1.16
+
 - 添加支持上传图像到 Github 仓库。
 
 ### 1.1.15
+
 - 添加文件格式化变量 `prompt`。可以在粘贴图像时通过输入框输入自定义名称。
 
 ### 1.1.14
+
 - 更新 Coding-Picbed 修复上传到 Coding 错误。
 
 ### 1.1.13
+
 - 添加了设置项目 `markdown-image.local.referencePath` 用于支持修改在 Markdown 文件中的图片引用路径。
 
 ### 1.1.12
+
 - 添加支持在 jupyter 文件中的粘贴图像。
 
 ### [1.1.11]
+
 - 更新了Cloudinary CDN 以使用 `markdown-image.base.fileNameFormat` 设置保存文件路徑。文件路径若已存在，将提示是否覆盖。
 
 ### 1.1.10
+
 - 添加了对 Cloudinary CDN 的支持
 - 新增了包括以下新的设置：
   * `markdown-image.cloudinary.cloudName`
@@ -238,61 +264,80 @@ sudo yum install xclip
   * `markdown-image.cloudinary.folder`
 
 ### 1.1.9
+
 - 添加设置选项 `markdown-image.base.codeType` 和 `markdown-image.base.imageWidth` 用于设置图片最大宽度。
 
 ### 1.1.8
+
 - 修正 VSCode 会缓存 `DIY` 路径代码，导致修改无法即时生效的问题。
 
 ### 1.1.7
+
 - 新增一个选项用于切换是否对 URL 编码。
 
 ### 1.1.6
+
 - 修正扩展 Log 等级，避免干扰其他扩展开发者。
 - 更新替换文件后动作。
 
 ### 1.1.5
+
 - 修正 `Data URL` 设定项目说明。
 
 ### 1.1.4
+
 - 新增插入 Markdown 图片方式： `Data URL`.
 - 修正粘贴多个文件无效问题。
 
 ### 1.1.3
-- 修复了文件名变量`${path}`导致在 Windows 系统下存在两级以上 Markdown 路径时，`Coding` 图床上传失败问题。
+
+- 修复了文件名变量 `${path}`导致在 Windows 系统下存在两级以上 Markdown 路径时，`Coding` 图床上传失败问题。
 
 ### 1.1.2
+
 - 再一次修复了粘贴复制的图片时，路径包含中文提示无法找到问题。😂
 
 ### 1.1.1
+
 - 修复了粘贴复制的图片时，路径包含中文提示无法找到问题。
 
 ### 1.1.0
+
 - 添加了 Beta 功能，支持粘贴富文本格式。 （仅支持Windows）
 
 ### 1.0.14
+
 - 修复了与 Windows 7 不兼容的问题。
 
 ### 1.0.13
+
 - 修复了在 Windows 中获取剪贴板图片的路径分辨率错误的问题。
 
 ### 1.0.12
+
 - 添加了文件名变量 `${path}`： 正在编辑的 Markdown 文件相对于根目录的路径。
 
 ### 1.0.11
+
 - 修正 `sm.ms` API 地址。
 - 修复了在 Linux 中找不到带空格的文件名的问题。
 - 添加了 `sm.ms` 没有设置 token 的提示。
 
 ### 1.0.10
+
 - 修复变量 `$mdname` 没有去除非 `md` 后缀名的问题。
 
 ### 1.0.9
+
 - 修复了文件名格式化日期小时获取错误的问题。
 
 ### 1.0.8
+
 - 加入支持 mdx 文件。
-- 
+-
+
 ### 1.0.7
+
 - 修复了无法自动在 MacOS 和 Linux 上启动扩展名主页的问题。
 - 修复了图片地址冒号被错误转义的问题。
 
@@ -320,12 +365,12 @@ sudo yum install xclip
 ### 1.0.1
 
 - 更新 Readme。
-  
+
 ### 1.0.0
 
 - 初版发布。
 
------------------------------------------------------------------------------------------------------------
+---
 
 ### 其他
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -8,7 +8,7 @@
 
 ## 功能
 
-1. 可複製圖片文件或截圖粘貼，快捷键 `Alt + Shift + V`，或右键菜单`粘贴图片`。
+1. 可複製圖片文件或截圖粘貼，快捷键 `Alt + Shift + V`，或右键菜单 `粘贴图片`。
 2. 自動生成 Markdown 代碼插入。
 3. 可配置支持 `Imgur`，`七牛`，`SM.MS`，`Coding` 等圖床。默認為本地，需打開 Markdown 文件所在文件夾。
 4. 也可以自定義代碼實現圖片上傳。
@@ -19,25 +19,29 @@
 Windows 和 MacOS 用戶可直接使用，Linux 用戶須安裝 xclip.
 
 Ubuntu
+
 ```bash
 sudo apt install xclip
 ```
 
 CentOS
+
 ```bash
 sudo yum install epel-release.noarch
 sudo yum install xclip
 ```
+
 ## 注意事項
 
 如果你要在 Remote 模式中使用，請設置 `remote.extensionKind` 如下：
+
 ```json
 "remote.extensionKind": {
   "hancel.markdown-image": [
     "ui"
   ]
 }
-``` 
+```
 
 而且，如果要將圖像保存在遠程工作目录中，則必須使用 `SFTP` 上傳方法，`Local` 方法無法在 Remote 模式中使用。
 
@@ -69,10 +73,11 @@ sudo yum install xclip
 - `markdown-image.github.repository`: 所要上傳的目的倉庫，比如：`https://github.com/username/repository/`。倉庫必須要先初始化。
 - `markdown-image.github.branch`: 要存放圖片的倉庫分支。
 - `markdown-image.github.cdn`: 要使用的 CDN 地址格式，`${username}` 表示上傳倉庫的用戶名，`${repository}` 表示上傳的倉庫，`${branch}` 表示上傳的分支，`${filepath}` 表示上傳的倉庫目錄與文件名。
+- `markdown-image.github.httpProxy` : 設置訪問Github的 HTTP 代理。
 
 ### Imgur 設置項目
 
-- `markdown-image.imgur.clientId`: 在 `imgur` 註冊的`Client Id`。您可以在[這裡](https://api.imgur.com/oauth2/addclient)註冊。
+- `markdown-image.imgur.clientId`: 在 `imgur` 註冊的 `Client Id`。您可以在[這裡](https://api.imgur.com/oauth2/addclient)註冊。
 - `markdown-image.imgur.httpProxy`: 設置訪問的 HTTP 代理。
 
 ### SM.MS 設置項目
@@ -97,14 +102,18 @@ sudo yum install xclip
 - `markdown-image.upyun.link`:  又拍雲鏈接線路。
 
 ### Cloudinary 設置項目
+
 這些值可以在 Cloudinary Dashboard 上找到
+
 - `markdown-image.cloudinary.cloudName`: 你的帳戶名稱。
 - `markdown-image.cloudinary.apiKey`: 你的帳戶 API key。
 - `markdown-image.cloudinary.apiSecret`: 你的帳戶 API secret。
 - `markdown-image.cloudinary.folder`: 圖像上傳文件夾。
 
 ### Cloudflare 設置項目
+
 這些值可以在 CloudFlare Dashboard 上找到
+
 - `markdown-image.cloudflare.accountId`: 你的帳戶名稱。
 - `markdown-image.cloudflare.apiToken`: Cloudflare API 令牌.
 
@@ -130,19 +139,20 @@ sudo yum install xclip
 
 ### 自定義設置項目
 
-- `markdown-image.DIY.path`: 你寫的代碼的路徑。你的代碼必須 exports 一個像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函數。   
-    比如：
-    ```javascript
-    const path = require('path');
-    module.exports = async function(filePath, savePath, markdownPath) {
-        // Return a picture access link
-        return path.relative(path.dirname(markdownPath), filePath);
-    }
-    ```
+- `markdown-image.DIY.path`: 你寫的代碼的路徑。你的代碼必須 exports 一個像 `async function (filePath:string, savePath:string, markdownPath:string):string` 的函數。
+  比如：
+  ```javascript
+  const path = require('path');
+  module.exports = async function(filePath, savePath, markdownPath) {
+      // Return a picture access link
+      return path.relative(path.dirname(markdownPath), filePath);
+  }
+  ```
 
 ## 發布歷史
 
 ### 1.1.29
+
 - 修正在 Deepin 系統無法獲取剪貼板圖片的問題。
 
 ### 1.1.28
@@ -170,6 +180,7 @@ sudo yum install xclip
   - `markdown-image.s3.secretAccessKey`
 
 ### 1.1.26
+
 - 添加了對 又拍雲 支持.
 - 新增了包括以下新的設置：
   * `markdown-image.upyun.bucket`
@@ -179,57 +190,72 @@ sudo yum install xclip
   * `markdown-image.upyun.path`
   * `markdown-image.upyun.link`
 
-
 ### 1.1.25
+
 - 修正當開啟 `markdown-image.base.urlEncode` 時，GitHub CDN 地址編碼錯誤的問題。
 
 ### 1.1.24
+
 - 修正一些 `markdown-image.local.referencePath` 的使用 bug；
 - 修正圖片 `alt` 計數在重載控件重新開始的問題。
 
 ### 1.1.23
+
 - 添加了新設置項目 `markdown-image.github.cdn` 去設置 GitHub CDN 地址.
 
 ### 1.1.22
+
 - 修复 GitHub 模式上傳文件路徑錯誤問題。
 
 ### 1.1.21
+
 - 修復了當文件路徑包含中文時，上傳到 GitHub 失敗的問題。
 
 ### 1.1.20
+
 - 修復 Local 模式設置 `local.referencePath` 以 `/` 開始的值導致路徑從磁盘根目录開始的问题。
 
 ### 1.1.19
+
 - 修復 Local 模式設置保存到項目根目錄，實際保存到磁盤根目錄問題。
 
 ### 1.1.18
+
 - 修復 Local 模式不能使用絕對路徑的問題。
 
 ### 1.1.17
+
 - 添加了對 Cloudflare CDN 支持.
 - 新增了包括以下新的設置：
   * `markdown-image.cloudflare.accountId`
   * `markdown-image.cloudflare.apiToken`
 
 ### 1.1.16
+
 - 添加支持上傳圖像到 Github 存儲庫。
 
 ### 1.1.15
+
 - 添加文件格式化變量 `prompt`。 可以在粘貼圖像時通過輸入框輸入自定義名稱。
 
 ### 1.1.14
+
 - 更新 Coding-Picbed 修復上傳到 Coding 錯誤。
 
 ### 1.1.13
+
 - 添加了設置项目 `markdown-image.local.referencePath` 用于支持修改在 Markdown 文件中的图片引用路徑。
 
 ### 1.1.12
+
 - 添加支持在 jupyter 文件中的粘貼圖像。
 
 ### [1.1.11]
+
 - 更新了Cloudinary CDN 以使用 `markdown-image.base.fileNameFormat` 設置保存文件路徑。文件路徑若已存在，將提示是否覆蓋。
 
 ### 1.1.10
+
 - 添加了對 Cloudinary CDN 的支持
 - 新增了包括以下新的設置：
   * `markdown-image.cloudinary.cloudName`
@@ -238,60 +264,79 @@ sudo yum install xclip
   * `markdown-image.cloudinary.folder`
 
 ### 1.1.9
+
 - 添加設置選項 `markdown-image.base.codeType` 和 `markdown-image.base.imageWidth` 用於設置圖片最大寬度。
 
 ### 1.1.8
+
 - 修正 VSCode 會緩存 `DIY` 路徑代碼，導致修改無法即時生效的問題。
 
 ### 1.1.7
+
 - 新增一個選項用於切換是否對 URL 編碼。
-  
+
 ### 1.1.6
+
 - 修正擴展Log等級，避免干擾其他擴展開發者。
-- 更新替換文件後動作。 
+- 更新替換文件後動作。
 
 ### 1.1.5
+
 - 修正 `Data URL` 設定項目説明。
 
 ### 1.1.4
+
 - 新增插入 Markdown 圖片方式： `Data URL`.
 - 修正粘貼多個文件無效問題。
 
 ### 1.1.3
-- 修复了文件名變量`${path}`導致在 Windows 系統下存在兩級以上 Markdown 路徑時，`Coding` 圖床上傳失敗問題。
+
+- 修复了文件名變量 `${path}`導致在 Windows 系統下存在兩級以上 Markdown 路徑時，`Coding` 圖床上傳失敗問題。
 
 ### 1.1.2
+
 - 再一次修復了粘貼複製的圖片時，路徑包含中文提示無法找到問題。😂
 
 ### 1.1.1
+
 - 修復了粘貼複製的圖片時，路徑包含中文提示無法找到問題。
 
 ### 1.1.0
+
 - 添加了 Beta 功能，支持粘貼富文本格式。（僅支持Windows）
 
 ### 1.0.14
+
 - 修復了與 Windows 7 不兼容的問題。
 
 ### 1.0.13
+
 - 修復了在 Windows 中獲取剪貼板圖片的路徑分辨率錯誤的問題。
 
 ### 1.0.12
+
 - 添加了文件名變量 `${path}`： 正在編輯的 Markdown 文件相對於根目錄的路徑。
 
 ### 1.0.11
+
 - 修正 `sm.ms` API 地址。
 - 修復了在 Linux 中找不到帶空格的文件名的問題。
 - 添加了 `sm.ms` 沒有設置 token 的提示。
+
 ### 1.0.10
+
 - 修復變量 `$mdname` 沒有去除非 `md` 後綴名的問題。
 
 ### 1.0.9
+
 - 修復了文件名格式化日期小時獲取錯誤的問題。
 
 ### 1.0.8
+
 - 加入支持 mdx 文件。
 
 ### 1.0.7
+
 - 修復了無法自動在 MacOS 和 Linux 上啟動擴展名主頁的問題。
 - 修復了圖片地址冒號被錯誤轉義的問題。
 
@@ -300,6 +345,7 @@ sudo yum install xclip
 - 修正日期變量沒有考慮時區的問題。
 
 ### 1.0.5
+
 - 修正包含空格的文件名無法預覽的問題。
 - 修正 ${rand} 變量不可用的問題。
 
@@ -323,7 +369,7 @@ sudo yum install xclip
 
 - 初版发布。
 
------------------------------------------------------------------------------------------------------------
+---
 
 ### 其他
 

--- a/asserts/linux.sh
+++ b/asserts/linux.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 
 # require xclip(see http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script/677212#677212)
-command -v xclip >/dev/null 2>&1 || { echo >&1 "no xclip"; exit 1; }
+command -v xclip >/dev/null 2>&1 || {
+	echo >&1 "no xclip"
+	exit 1
+}
 
 # write image in clipboard to file (see http://unix.stackexchange.com/questions/145131/copy-image-from-clipboard-to-file)
 xclip -selection clipboard -target image/png -o >$1
 if [ $? -eq 0 ]; then
-echo $1
+	echo $1
 else
-content=$(xclip -selection c -o)
-echo $content
+	content=$(xclip -selection c -o)
+	echo $content
 fi

--- a/package.json
+++ b/package.json
@@ -213,6 +213,12 @@
             "markdownDescription": "%markdown-image.github.token%",
             "order": 1,
             "type": "string"
+					},
+					"markdown-image.github.httpProxy": {
+						"default": "",
+						"markdownDescription": "%markdown-image.github.httpProxy%",
+						"order": 5,
+						"type": "string"
           }
         },
         "title": "GitHub"

--- a/package.nls.json
+++ b/package.nls.json
@@ -38,6 +38,7 @@
   "markdown-image.github.repository": "GitHub repository, for example: `https://github.com/username/repository`",
   "markdown-image.github.branch": "GitHub repository branch to save.",
   "markdown-image.github.cdn": "The github cdn address format to be used, `${username}` is the username of `#markdown-image.github.repository#`, and `${repository}` is the repository name. `${branch}` is the value of `#markdown-image.github.branch#`. `${filepath}` is the upload path in repository.",
+  "markdown-image.github.httpProxy": "Connect to Github via http proxy.",
   "markdown-image.imgur.clientId": "The client id registered with imgur. You can registed it at [here](https://api.imgur.com/oauth2/addclient).",
   "markdown-image.imgur.httpProxy": "Connect to Imgur via http proxy.",
   "markdown-image.sm_ms.token": "SM.MS API token (Options). You can register an account and then visit [API Token](https://smms.app/home/apitoken) Page to generate secret token.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -35,6 +35,7 @@
     "markdown-image.github.repository": "所要上传的目的仓库，比如：`https://github.com/username/repository/`。仓库必须要先初始化。",
     "markdown-image.github.branch": "要存放图片的仓库分支。",
     "markdown-image.github.cdn": "要使用的 CDN 地址格式，${username} 表示上传仓库的用户名，${repository} 表示上传的仓库，${branch} 表示上传的分支，${filepath} 表示上传的仓库目录与文件名。",
+    "markdown-image.github.httpProxy": "通过 HTTP 代理连接到 Github",
     "markdown-image.imgur.clientId": "在 `imgur` 注册的 `Client Id`。您可以在[这儿](https://api.imgur.com/oauth2/addclient)注册。",
     "markdown-image.imgur.httpProxy": "通过 HTTP 代理连接到 Imgur。",
     "markdown-image.sm_ms.token": "SM.MS Secret Token。您可以注册一个帐户，然后访问 [API Access](https://smms.app/home/apitoken) 页面以生成。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -34,6 +34,7 @@
     "markdown-image.github.repository": "所要上傳的目的倉庫，比如：`https://github.com/username/repository/`。倉庫必須要先初始化。 ",
     "markdown-image.github.branch": "要存放圖片的倉庫分支。",
     "markdown-image.github.cdn": "要使用的 CDN 地址格式，${username} 表示上傳倉庫的用戶名，${repository} 表示上傳的倉庫，${branch} 表示上傳的分支，${filepath} 表示上傳的倉庫目錄與文件名。",
+    "markdown-image.github.httpProxy": "通過 HTTP 代理連接到 Github。",
     "markdown-image.imgur.clientId": "在 `imgur` 註冊的 `Client Id`。您可以在[這兒](https://api.imgur.com/oauth2/addclient)註冊。",
     "markdown-image.imgur.httpProxy": "通過 HTTP 代理連接到 Imgur。",
     "markdown-image.sm_ms.token": "SM.MS Secret Token。您可以註冊一個帳戶，然後訪問 [API Access](https://smms.app/home/apitoken) 頁面生成。",


### PR DESCRIPTION
github上传添加代理支持，对应的修改了https://github.com/imlinhanchao/github-picbed/pull/1

第二个问题为linux环境下面上传图片不成功，对应编辑更新了linux.sh文件。
版本: 1.78.2
提交: b3e4e68a0bc097f0ae7907b217c1119af9e03435
日期: 2023-05-10T14:47:05.613Z
浏览器: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.78.2 Chrome/108.0.5359.215 Electron/22.5.2 Safari/537.36

Linux环境上面通过vscode安装完成后的linux.sh里面文件换行为CRLF，通过vscode打开linux.sh，将换行调整为LF后重新保存后能够正确上传。