### PR TITLE
fix: PNG transparent background turning black bug

### DIFF
--- a/asserts/pc.ps1
+++ b/asserts/pc.ps1
@@ -21,7 +21,7 @@ if (-not $imagePath) {
     Exit 1
 }
 
-$fcb = new-object Windows.Media.Imaging.FormatConvertedBitmap($img, [Windows.Media.PixelFormats]::Rgb24, $null, 0)
+$fcb = new-object Windows.Media.Imaging.FormatConvertedBitmap($img, [Windows.Media.PixelFormats]::Pbgra32, $null, 0)
 $stream = [IO.File]::Open($imagePath, "OpenOrCreate")
 $encoder = New-Object Windows.Media.Imaging.PngBitmapEncoder
 $encoder.Frames.Add([Windows.Media.Imaging.BitmapFrame]::Create($fcb)) | out-null


### PR DESCRIPTION
see: https://github.com/imlinhanchao/vsc-markdown-image/issues/147